### PR TITLE
more flexible 0% step keyframes fix

### DIFF
--- a/cssmin.php
+++ b/cssmin.php
@@ -337,7 +337,7 @@ class CSSmin
         $css = preg_replace('/(^|[^0-9])(?:0?\.)?0(?:em|ex|ch|rem|vw|vh|vm|vmin|cm|mm|in|px|pt|pc|%|deg|g?rad|m?s|k?hz)/iS', '${1}0', $css);
 
 		// 0% step in a keyframe? restore the % unit
-		$css = preg_replace('/(@[a-z\-]*?keyframes.*?)0\{/iS', '${1}0%{', $css);
+		$css = preg_replace_callback('/(@[a-z\-]*?keyframes.*?\{)(.*?\{)/is', array($this, 'replace_keyframe_zero'), $css);
 
         // Replace 0 0; or 0 0 0; or 0 0 0 0; with 0.
         $css = preg_replace('/\:0(?: 0){1,3}(;|\}| \!)/', ':0$1', $css);
@@ -583,6 +583,11 @@ class CSSmin
     {
         $this->preserved_tokens[] = trim(preg_replace('/\s*([\*\/\(\),])\s*/', '$1', $matches[2]));
         return 'calc('. self::TOKEN . (count($this->preserved_tokens) - 1) . '___' . ')';
+    }
+
+    private function replace_keyframe_zero($matches)
+    {
+        return $matches[1] . str_replace('0{', '0%{', str_replace('0,', '0%,', $matches[2]));
     }
 
     private function rgb_to_hex($matches)


### PR DESCRIPTION
Thank you so much for making this port. Loving it!

I was doing some testing and found that @keyframes with grouped selector steps like '0%,100%' were coming out as '0,100%'.

So, this pull request will happily deal with that common scenario and it even works for odd edge cases like...

@keyframes name{0,to,from{...}to{...}};
@keyframes name{100%,to,from{...}to{...}};
@keyframes name{100%,0,to{...}to{...}};
@keyframes name{from,0,to{...}to{...}};
@keyframes name{from,to,0{...}to{...}};
@keyframes name{from,to{...}to{...}};

Please let me know if you see anything you want to tweaked or if there are any tests I can help with. Very happy to help. :D

PS - I had tried most of the popular PHP minifiers out there and they all had serious problems. I was dreading the prospecting of having to code my own from scratch so you can imagine how happy I was to discover your code! Thank you so much. ^_^
