### PR TITLE
Fix timeout getting changed to 60 seconds when set to 0 (unlimited)

### DIFF
--- a/cssmin.php
+++ b/cssmin.php
@@ -200,8 +200,12 @@ class CSSmin
         // If current settings are higher respect them.
         foreach ($php_limits as $name => $suggested) {
             $current = $this->normalize_int(ini_get($name));
+            // max_execution_time of 0 is unlimited.
+	    if ($name === 'max_execution_time' && $current > 0 && $current < $suggested) {
+	      ini_set($name, $suggested);
+	    }
             // memory_limit exception: allow -1 for "no memory limit".
-            if ($current > -1 && ($suggested == -1 || $current < $suggested)) {
+            elseif ($current > -1 && ($suggested == -1 || $current < $suggested)) {
                 ini_set($name, $suggested);
             }
         }


### PR DESCRIPTION
When running from the command line the timeout is usually 0 (unlimited); looking at the code it doesn't take this into account and assumes that 60 is higher than 0 in this case.
