### PR TITLE
Avoid non well formed numeric values in normalize_int

### DIFF
--- a/cssmin.php
+++ b/cssmin.php
@@ -766,9 +766,9 @@ class CSSmin
     {
         if (is_string($size)) {
             switch (substr($size, -1)) {
-                case 'M': case 'm': return $size * 1048576;
-                case 'K': case 'k': return $size * 1024;
-                case 'G': case 'g': return $size * 1073741824;
+                case 'M': case 'm': return (int) $size * 1048576;
+                case 'K': case 'k': return (int) $size * 1024;
+                case 'G': case 'g': return (int) $size * 1073741824;
             }
         }
 


### PR DESCRIPTION
PHP 7.1 actively complains about this:
for example multiplying 128M * 1048576 instead of 128 * 1048576.