### PR TITLE
Update CSSmin.php to satisfy PHP 7.1 requirements

### DIFF
--- a/cssmin.php
+++ b/cssmin.php
@@ -765,13 +765,14 @@ class CSSmin
     private function normalize_int($size)
     {
         if (is_string($size)) {
-            switch (substr($size, -1)) {
+            $letter = substr($size, -1);
+            $size = intval($size);
+            switch ($letter) {
                 case 'M': case 'm': return $size * 1048576;
                 case 'K': case 'k': return $size * 1024;
                 case 'G': case 'g': return $size * 1073741824;
             }
         }
-
         return (int) $size;
     }
 }


### PR DESCRIPTION
For now PHP 7.1 gives "A non well formed numeric value encountered" if we're trying to multiply string with number.
It's all about strict typecasting.