### PR TITLE
Prevent unquoted font family names that match color names from being …

### DIFF
--- a/src/Minifier.php
+++ b/src/Minifier.php
@@ -631,7 +631,7 @@ class Minifier
         );
 
         // Restore unquoted font tokens now after colors have been changed.
-        $body = $this->restoreUnqoutedFontTokens($body);
+        $body = $this->restoreUnquotedFontTokens($body);
 
         // Replace positive sign from numbers before the leading space is removed.
         // +1.2em to 1.2em, +.8px to .8px, +2% to 2%
@@ -725,7 +725,7 @@ class Minifier
         return $this->registerUnquotedFontToken($matches[0]);
     }
 
-    private function restoreUnqoutedFontTokens($body)
+    private function restoreUnquotedFontTokens($body)
     {
         return strtr($body, $this->unquotedFontTokens);
     }

--- a/src/Minifier.php
+++ b/src/Minifier.php
@@ -64,7 +64,7 @@ class Minifier
     private $shortenThreeZeroesRegex;
     private $shortenFourZeroesRegex;
     private $unitsGroupRegex = '(?:ch|cm|em|ex|gd|in|mm|px|pt|pc|q|rem|vh|vmax|vmin|vw|%)';
-    private $unquotedFontsRegex = '/(font-family:|font:)([^ \'"]+?)[^}]*/Si';
+    private $unquotedFontsRegex = '/(font-family:|font:)([^\'"]+?)[^};]*/Si';
 
     /**
      * @param bool|int $raisePhpLimits If true, PHP settings will be raised if needed

--- a/src/Minifier.php
+++ b/src/Minifier.php
@@ -29,28 +29,30 @@ class Minifier
     const COMMENT_TOKEN_START = '_CSSMIN_CMT_';
     const RULE_BODY_TOKEN = '_CSSMIN_RBT_%d_';
     const PRESERVED_TOKEN = '_CSSMIN_PTK_%d_';
-    
+    const UNQUOTED_FONT_TOKEN = '_CSSMIN_UFT_%d_';
+
     // Token lists
     private $comments = array();
     private $ruleBodies = array();
     private $preservedTokens = array();
-    
+    private $unquotedFontTokens = array();
+
     // Output options
     private $keepImportantComments = true;
     private $keepSourceMapComment = false;
     private $linebreakPosition = 0;
-    
+
     // PHP ini limits
     private $raisePhpLimits;
     private $memoryLimit;
     private $maxExecutionTime = 60; // 1 min
     private $pcreBacktrackLimit;
     private $pcreRecursionLimit;
-    
+
     // Color maps
     private $hexToNamedColorsMap;
     private $namedToHexColorsMap;
-    
+
     // Regexes
     private $numRegex;
     private $charsetRegex = '/@charset [^;]+;/Si';
@@ -62,6 +64,7 @@ class Minifier
     private $shortenThreeZeroesRegex;
     private $shortenFourZeroesRegex;
     private $unitsGroupRegex = '(?:ch|cm|em|ex|gd|in|mm|px|pt|pc|q|rem|vh|vmax|vmin|vw|%)';
+    private $unquotedFontsRegex = '/(font-family:|font:)([^ \'"]+?)[^}]*/Si';
 
     /**
      * @param bool|int $raisePhpLimits If true, PHP settings will be raised if needed
@@ -284,6 +287,17 @@ class Minifier
 
         $tokenId = sprintf(self::RULE_BODY_TOKEN, count($this->ruleBodies));
         $this->ruleBodies[$tokenId] = $body;
+        return $tokenId;
+    }
+
+    private function registerUnquotedFontToken($body)
+    {
+        if (empty($body)) {
+            return '';
+        }
+
+        $tokenId = sprintf(self::UNQUOTED_FONT_TOKEN, count($this->unquotedFontTokens));
+        $this->unquotedFontTokens[$tokenId] = $body;
         return $tokenId;
     }
 
@@ -600,6 +614,14 @@ class Minifier
             $body
         );
 
+        // Tokenize unquoted font names in order to hide them from
+        // color name replacements.
+        $body = preg_replace_callback(
+            $this->unquotedFontsRegex,
+            array($this, 'preserveUnquotedFontTokens'),
+            $body
+        );
+
         // Shorten long named colors with a shorter HEX counterpart: white -> #fff.
         // Run at least 2 times to cover most cases
         $body = preg_replace_callback(
@@ -607,6 +629,9 @@ class Minifier
             array($this, 'shortenNamedColorsCallback'),
             $body
         );
+
+        // Restore unquoted font tokens now after colors have been changed.
+        $body = $this->restoreUnqoutedFontTokens($body);
 
         // Replace positive sign from numbers before the leading space is removed.
         // +1.2em to 1.2em, +.8px to .8px, +2% to 2%
@@ -693,6 +718,16 @@ class Minifier
         $body = preg_replace_callback('/(?:^|;)[A-Z-]+:/S', array($this, 'strtolowerCallback'), $body);
 
         return $body;
+    }
+
+    private function preserveUnquotedFontTokens($matches)
+    {
+        return $this->registerUnquotedFontToken($matches[0]);
+    }
+
+    private function restoreUnqoutedFontTokens($body)
+    {
+        return strtr($body, $this->unquotedFontTokens);
     }
 
     /**

--- a/tests/MinifierTest.php
+++ b/tests/MinifierTest.php
@@ -172,6 +172,11 @@ class MinifierTest extends PHPUnit_Framework_TestCase
         $this->execTest('font-weight');
     }
 
+    public function testFontFamilyColor()
+    {
+        $this->execTest('font-family-color');
+    }
+
     public function testImportantRule()
     {
         $this->execTest('important');

--- a/tests/expectations/font-family-color.css
+++ b/tests/expectations/font-family-color.css
@@ -1,0 +1,1 @@
+.full-width-content .nectar-recent-posts-slider{font:italic 1.2em Fira White,serif}.recent-post-container .inner-wrap h2{font-family:Archivo Black;text-transform:capitalize;letter-spacing:0;font-size:60px;line-height:74px;font-weight:400}

--- a/tests/fixtures/font-family-color.css
+++ b/tests/fixtures/font-family-color.css
@@ -1,0 +1,2 @@
+.full-width-content .nectar-recent-posts-slider{font: italic 1.2em Fira White, serif;}
+.recent-post-container .inner-wrap h2{font-family:Archivo Black;text-transform:capitalize;letter-spacing:0;font-size:60px;line-height:74px;font-weight:400;}


### PR DESCRIPTION
…replaced

Fixes #48 in a relatively crude fashion, but other attempts at fixing it quickly only resulted in breaking some other existing test cases.

A test is in there too now to cover the expected behaviour.