### PR TITLE
issue Number #51 : Resolved PHP 7.2 compatibility

### DIFF
--- a/gui/index.php
+++ b/gui/index.php
@@ -33,7 +33,6 @@ function stripslashes_deep($value)
 
 // Disable magic quotes at runtime.
 if (function_exists('ini_set')) {
-    ini_set('magic_quotes_sybase', 0);
     ini_set('get_magic_quotes_runtime', 0);
 }
 
@@ -45,7 +44,7 @@ if (function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc()) {
 
 if (!empty($_POST)) :
     // Form options
-    parse_str($_POST['options']);
+    parse_str($_POST['options'], $result);
 
     $linebreak_pos = trim($linebreak_pos) !== '' ? $linebreak_pos : false;
     $raise_php = isset($raise_php) ? true : false;


### PR DESCRIPTION
There are a couple of minor PHP 7.2 incompatibilities in this project, both in gui/index.php:

ini_set('magic_quotes_sybase', 0); --> this directive has been removed. I guess it's safe also to disable it.
parse_str($_POST['options']); --> parse_str now requires the return parameter to be set. I searched across the code and couldn't find
Would it be ok to raise the PHP minimum version requirement? I can raise a PR if you want